### PR TITLE
pear-next

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bot Service
-- Run bot as a pear app (via Pear.worker)
-- Auto restart bot on update (via Pear.updates)
+- Run bot as a pear app (via pear-run)
+- Auto restart bot on update (via pear-updates)
 
 ## Sample bot
 - create `main.js` as the main entry point, then run `botService.main(<path-to-bot>)`

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function main (botPath, opts = {}) {
 
   let onData = noop
   let onError = noop
-  const pipe = Pear.worker.pipe()
+  const pipe = Pear.pipe
   if (pipe) {
     onData = (data) => pipe.write(JSON.stringify({ tag: 'data', data }) + '\n')
     onError = (data) => pipe.write(JSON.stringify({ tag: 'error', data }) + '\n')
@@ -117,7 +117,7 @@ function startWorker (runLink, onData, onError) {
   const closedPr = promiseWithResolvers()
   const versionPr = promiseWithResolvers()
 
-  const pipe = Pear.worker.run(runLink, Pear.config.args)
+  const pipe = Pear.run(runLink, Pear.config.args)
   pipe.on('data', (data) => {
     const lines = data.toString().split('\n')
     for (let msg of lines) {
@@ -199,7 +199,7 @@ function hasUpdateDev (watchPrefixes, diff) {
  * ): Promise<void>}
  */
 async function run (botRunner) {
-  const pipe = Pear.worker.pipe()
+  const pipe = Pear.pipe
   if (pipe) { // handle uncaught errors from botRunner
     process.on('uncaughtException', (err) => {
       pipe.write(JSON.stringify({ tag: 'error', data: `${err?.stack || err}` }) + '\n')

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
   },
   "dependencies": {
     "bare-process": "^4.2.1",
-    "debounceify": "^1.1.0"
+    "debounceify": "^1.1.0",
+    "pear-pipe": "^1.0.3",
+    "pear-run": "^1.0.0",
+    "pear-updates": "^1.1.0"
   },
   "devDependencies": {
     "bare-fs": "^4.4.4",

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "bare-process": "^4.2.1",
     "debounceify": "^1.1.0",
     "pear-pipe": "^1.0.3",
-    "pear-run": "^1.0.0",
+    "pear-run": "^1.0.1",
     "pear-updates": "^1.1.0"
   },
   "devDependencies": {
-    "bare-fs": "^4.4.4",
+    "bare-fs": "^4.4.5",
     "bare-path": "^3.0.0",
-    "bare-subprocess": "^5.1.2",
+    "bare-subprocess": "^5.1.4",
     "brittle": "^3.19.0",
     "pear-interface": "^1.1.0",
     "standard": "^17.1.2"

--- a/test/fixtures/worker/parent/index.js
+++ b/test/fixtures/worker/parent/index.js
@@ -1,6 +1,7 @@
 /* global Pear */
 
-const pipe = Pear.worker.run(`pear://${Pear.config.args[0]}/test/fixtures/worker/child/main.js`)
+const pearRun = require('pear-run')
+const pipe = pearRun(`pear://${Pear.config.args[0]}/test/fixtures/worker/child/main.js`)
 
 pipe.on('data', (data) => {
   const lines = data.toString().split('\n')

--- a/test/fixtures/worker/parent/package.json
+++ b/test/fixtures/worker/parent/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@holepunchto/bot-service-parent",
   "main": "index.js",
-  "pear": {}
+  "pear": {},
+  "dependencies": {
+    "pear-run": "^1.0.0"
+  }
 }


### PR DESCRIPTION
`npm t` in local

```
-> % npm t

> @holepunchto/bot-service@1.1.17 test
> brittle-bare -c test/all.mjs

TAP version 13

# basic - direct run
    ok 1 - output is correct
    ok 2 - args[0] is correct
    ok 3 - args[1] is correct
ok 1 - basic - direct run # time = 2120ms

# basic - start main
    ok 1 - worker output is correct
    ok 2 - bot output is correct
    ok 3 - bot args[0] is correct
    ok 4 - bot args[1] is correct
ok 2 - basic - start main # time = 2246ms

# error
    ok 1 - error message is correct
ok 3 - error # time = 276ms

# error - uncaught exception
    ok 1 - error message is correct
ok 4 - error - uncaught exception # time = 2212ms

# update
    ok 1 - stage1 done
    ok 2 - worker started on version 0.7865
    ok 3 - stage2 done
    ok 4 - worker updated to new version 0.7867
ok 5 - update # time = 12512ms

# user app starts bot-service in a worker
    ok 1 - stageParent done
    ok 2 - stageChild done
ok 6 - user app starts bot-service in a worker # time = 8474ms

1..6
# tests = 6/6 pass
# asserts = 15/15 pass
# time = 27870ms

# ok
-------|---------|----------|---------|---------|-------------------
File   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------|---------|----------|---------|---------|-------------------
 All … |     100 |      100 |     100 |     100 |                   
-------|---------|----------|---------|---------|-------------------
```